### PR TITLE
fix: correct "lacks of" typo in unsupported-CPU panic

### DIFF
--- a/internal/native/dispatch.go
+++ b/internal/native/dispatch.go
@@ -75,6 +75,6 @@ func init() {
 	} else if hasSSE {
 		useSSE()
 	} else {
-		panic("Unsupported CPU, lacks of AVX2 or SSE CPUID Flag. maybe it's too old to run Sonic.")
+		panic("Unsupported CPU, lacks AVX2 or SSE CPUID Flag. maybe it's too old to run Sonic.")
 	}
 }


### PR DESCRIPTION
## Summary
Panic message said \"lacks of AVX2\"; use \"lacks AVX2\".

## Test plan
- [x] `go test .`